### PR TITLE
Remove unnecessary api call while detecting MFA accounts

### DIFF
--- a/tesla.py
+++ b/tesla.py
@@ -35,8 +35,6 @@ def create_driver():
 
 
 def login(args):
-    print("started")
-
     email, password = args.email, args.password
     session, resp, params, code_verifier = (None,) * 4
     vprint = print if args.verbose else lambda *_: None

--- a/tesla.py
+++ b/tesla.py
@@ -35,6 +35,8 @@ def create_driver():
 
 
 def login(args):
+    print("started")
+
     email, password = args.email, args.password
     session, resp, params, code_verifier = (None,) * 4
     vprint = print if args.verbose else lambda *_: None
@@ -109,6 +111,10 @@ def login(args):
         if resp.ok and (resp.status_code == 302 or "<title>" in resp.text):
             vprint(f"Post auth form success - {attempt + 1} attempt(s).")
             break
+        elif resp.ok and (resp.status_code == 200 and "/mfa/verify" in resp.text):
+            # break here itself, if mfa is detected. No need to keep the loop running
+            break
+
         time.sleep(3)
     else:
         raise ValueError(f"Didn't post auth form in {MAX_ATTEMPTS} attempts.")


### PR DESCRIPTION
The original script, kept the loop running even when the response was 200 and was a MFA account, It only checked whether an account was MFA after MAX attempts have been made. This lead to unnecessary api calls whenever the account was a MFA account.

I have added a simple elif condition to detect whether an account is mfa in the loop itself, thus breaking out of the loop as soon as mfa is detected. 